### PR TITLE
added functionality making hidden locations

### DIFF
--- a/world-builder/app/controllers/campaigns_controller.rb
+++ b/world-builder/app/controllers/campaigns_controller.rb
@@ -12,6 +12,7 @@ class CampaignsController < ApplicationController
         @users = User.all
         @locations = Location.all
         @continents = Location.where(tag_id: 1)
+        @hcontinents = Location.where(tag_id: 1, hidden:false)
         @user_campaigns = UserCampaign.all
         id = params[:id] # retrieve movie ID from URI route
         @campaign = Campaign.find(id) # look up movie by unique ID

--- a/world-builder/app/controllers/locations_controller.rb
+++ b/world-builder/app/controllers/locations_controller.rb
@@ -9,11 +9,17 @@ class LocationsController < ApplicationController
         @regions = Location.where(tag_id: 3)
         @cities = Location.where(tag_id: 4)
         @buildings = Location.where(tag_id: 5)
-        @worlds = World.all
+        
+        @hcountries = Location.where(tag_id: 2, hidden:false)
+        @hregions = Location.where(tag_id: 3, hidden:false)
+        @hcities = Location.where(tag_id: 4, hidden:false)
+        @hbuildings = Location.where(tag_id: 5, hidden:false)
         
         id = params[:id] # retrieve movie ID from URI route
         @location = Location.find(id) # look up movie by unique ID
         # will render app/views/movies/show.html.haml by default
+        gm = params[:gm]
+        @gm = gm
     end
     
     def new
@@ -22,12 +28,12 @@ class LocationsController < ApplicationController
     end 
 
     def location_params
-        params.require(:location).permit(:name,:description,:world_name,:gm_note,:character_note)
+        params.require(:location).permit(:name,:description,:world_name,:tag_id,:gm_note,:character_note,:hidden)
     end
 
     def create
         params.require(:location)
-        params[:location].permit(:name,:description,:world_id)
+        params[:location].permit(:name,:description,:world_id,:tag_id)
         # shortcut: params.require(:movie).permit(:title,:rating,:release_date)
         # rest of code...
         @location = Location.create!(location_params)

--- a/world-builder/app/models/location.rb
+++ b/world-builder/app/models/location.rb
@@ -4,4 +4,23 @@ class Location < ActiveRecord::Base
     has_many :npcs
     has_many :parent_locations, :class_name => 'Connection'
     has_many :child_locations, :class_name => 'Connection'
+    
+        # setters and getters for tag foreign key
+    def tag_name=(name)
+        self.tag = Tag.find_or_create_by(name: name)
+    end
+
+    def tag_name
+        self.tag ? self.tag.name : nil
+    end
+    
+        # setters and getters for world foreign key
+    def world_name=(name)
+        self.world = World.find_or_create_by(name: name)
+    end
+
+    def world_name
+        self.world ? self.world.name : nil
+    end
+
 end

--- a/world-builder/app/views/campaigns/show.html.haml
+++ b/world-builder/app/views/campaigns/show.html.haml
@@ -36,5 +36,4 @@
     %tbody
       - @continents.where(:world_id => @campaign.world_id).each do |continent|
         %tr
-          %td= link_to "#{continent.name}", location_path(continent)
-          %end
+          %td= link_to "#{continent.name}", location_path(continent, gm: @campaign.user_id)

--- a/world-builder/app/views/campaigns/show.html.haml
+++ b/world-builder/app/views/campaigns/show.html.haml
@@ -27,13 +27,28 @@
             %tr
               %td #{user.name}
 
-
-.left.column
-  %table#campaigns
-    %thead
-      %tr
-        %th Continents
-    %tbody
-      - @continents.where(:world_id => @campaign.world_id).each do |continent|
+- if current_user.id == @campaign.user_id
+  .left.column
+    %table#campaigns
+      %thead
         %tr
-          %td= link_to "#{continent.name}", location_path(continent, gm: @campaign.user_id)
+          %th Continents
+      %tbody
+        - @continents.where(:world_id => @campaign.world_id).each do |continent|
+          -if continent.hidden == true
+            %tr
+              %td= link_to "#{continent.name} - (hidden to players)", location_path(continent, gm: @campaign.user_id)
+          - else
+            %tr
+              %td= link_to "#{continent.name}", location_path(continent, gm: @campaign.user_id)
+
+- else 
+  .left.column
+    %table#campaigns
+      %thead
+        %tr
+          %th Continents
+      %tbody
+        - @hcontinents.where(:world_id => @campaign.world_id).each do |continent|
+          %tr
+            %td= link_to "#{continent.name}", location_path(continent, gm: @campaign.user_id)

--- a/world-builder/app/views/locations/edit.html.haml
+++ b/world-builder/app/views/locations/edit.html.haml
@@ -14,6 +14,9 @@
   = label :location, :world_id, 'Select a World for your Location'
   = collection_select(:location, :world_id,World.all,:name,:name,prompt:true)
   
+  = label :location, :hidden, 'check box if location is stil unknown (hidden)'
+  = check_box :location, :hidden
+  
 
   
   = submit_tag 'Save Changes'

--- a/world-builder/app/views/locations/new.html.haml
+++ b/world-builder/app/views/locations/new.html.haml
@@ -2,6 +2,15 @@
 
 = form_tag locations_path, :method => :post do
 
+  = label :location, :world_id, 'Select a World for your Campaign'
+  = collection_select(:location, :world_name, World.all, :name, :name, prompt: true)
+  
+  = label :location, :tag_id, 'Location Type'
+  = collection_select(:location, :tag_name, Tag.all, :name, :name, prompt:true)
+  
+  = label :location, :name, 'This Location is Located Within:'
+  = collection_select(:connection, :parent_location_id,Location.all,:name,:name, prompt:true)
+
   = label :location, :name, 'Name'
   = text_field :location, :name
 
@@ -11,8 +20,7 @@
   = label :location, :gm_note, 'GM Note'
   = text_field :location, :gm_note
   
-  = label :location, :world_id, 'Select a World for your Location'
-  = collection_select(:location, :world_id,World.all,:name,:name, prompt:true)
+  
 
   = submit_tag 'Save Changes'
 = link_to 'Back to location list', locations_path, :class => 'button'

--- a/world-builder/app/views/locations/show.html.haml
+++ b/world-builder/app/views/locations/show.html.haml
@@ -1,5 +1,9 @@
 = link_to 'Back to location list', locations_path, :class => 'button'
 
+- if current_user.id == @gm.to_i
+  %p
+    = link_to 'Edit Location Details', edit_location_path, :class => "button"
+
 %h2 #{@location.name}
 
 %ul#details
@@ -18,47 +22,75 @@
 %h4 Player Note:
 
 %div#player_note= @location.player_note
-.left.column
-  %table#worlds
-    %thead
-      %tr
-        %th My World
-    %tbody
-      -@worlds.where(:id => @location.world_id).each do |world|
-        %tr
-          %td= link_to "#{world.name}", world_path(world)
 
 
-.left.column
-  - if @location.tag_id < 5
-    %table#campaigns
-      %thead
-        %tr
-          %th #{@tags = Tag.find(@location.tag_id + 1).name + " List"}
-      %tbody
-        - if @location.tag_id == 1
-          - @connections.where(:parent_location_id => @location.id).each do |connection|
-            - @countries.where(:id => connection.child_location_id).each do |country|
-              %tr
-                %td= link_to "#{country.name}", location_path(country)
-                
-        - if @location.tag_id == 2
-          - @connections.where(:parent_location_id => @location.id).each do |connection|
-            - @regions.where(:id => connection.child_location_id).each do |region|
-              %tr
-                %td= link_to "#{region.name}", location_path(region)
-        
-        - if @location.tag_id == 3
-          - @connections.where(:parent_location_id => @location.id).each do |connection|
-            - @cities.where(:id => connection.child_location_id).each do |city|
-              %tr
-                %td= link_to "#{city.name}", location_path(city)
-                
-        - if @location.tag_id == 4
-          - @connections.where(:parent_location_id => @location.id).each do |connection|
-            - @buildings.where(:id => connection.child_location_id).each do |building|
-              %tr
-                %td= link_to "#{building.name}", location_path(building)
+- if current_user.id == @gm.to_i
+  .left.column
+    - if @location.tag_id < 5
+      %table#campaigns
+        %thead
+          %tr
+            %th #{@tags = Tag.find(@location.tag_id + 1).name + " List"}
+        %tbody
+          - if @location.tag_id == 1
+            - @connections.where(:parent_location_id => @location.id).each do |connection|
+              - @countries.where(:id => connection.child_location_id).each do |country|
+                - if country.hidden == true
+                  %tr
+                    %td= link_to "#{country.name} - hidden ", location_path(country, gm: @gm)
+                - else
+                  %tr
+                    %td= link_to "#{country.name}", location_path(country, gm: @gm)
+                  
+          - if @location.tag_id == 2
+            - @connections.where(:parent_location_id => @location.id).each do |connection|
+              - @regions.where(:id => connection.child_location_id).each do |region|
+                %tr
+                  %td= link_to "#{region.name}", location_path(region, gm: @gm)
+          
+          - if @location.tag_id == 3
+            - @connections.where(:parent_location_id => @location.id).each do |connection|
+              - @cities.where(:id => connection.child_location_id).each do |city|
+                %tr
+                  %td= link_to "#{city.name}", location_path(city, gm: @gm)
+                  
+          - if @location.tag_id == 4
+            - @connections.where(:parent_location_id => @location.id).each do |connection|
+              - @buildings.where(:id => connection.child_location_id).each do |building|
+                %tr
+                  %td= link_to "#{building.name}", location_path(building, gm: @gm)
+
+- else
+  .left.column
+    - if @location.tag_id < 5
+      %table#campaigns
+        %thead
+          %tr
+            %th #{@tags = Tag.find(@location.tag_id + 1).name + " List"}
+        %tbody
+          - if @location.tag_id == 1
+            - @connections.where(:parent_location_id => @location.id).each do |connection|
+              - @hcountries.where(:id => connection.child_location_id).each do |country|
+                %tr
+                  %td= link_to "#{country.name}", location_path(country)
+                  
+          - if @location.tag_id == 2
+            - @connections.where(:parent_location_id => @location.id).each do |connection|
+              - @hregions.where(:id => connection.child_location_id).each do |region|
+                %tr
+                  %td= link_to "#{region.name}", location_path(region)
+          
+          - if @location.tag_id == 3
+            - @connections.where(:parent_location_id => @location.id).each do |connection|
+              - @hcities.where(:id => connection.child_location_id).each do |city|
+                %tr
+                  %td= link_to "#{city.name}", location_path(city)
+                  
+          - if @location.tag_id == 4
+            - @connections.where(:parent_location_id => @location.id).each do |connection|
+              - @hbuildings.where(:id => connection.child_location_id).each do |building|
+                %tr
+                  %td= link_to "#{building.name}", location_path(building)
             
       
           

--- a/world-builder/app/views/locations/show.html.haml
+++ b/world-builder/app/views/locations/show.html.haml
@@ -37,7 +37,7 @@
               - @countries.where(:id => connection.child_location_id).each do |country|
                 - if country.hidden == true
                   %tr
-                    %td= link_to "#{country.name} - hidden ", location_path(country, gm: @gm)
+                    %td= link_to "#{country.name} - (hidden to players)", location_path(country, gm: @gm)
                 - else
                   %tr
                     %td= link_to "#{country.name}", location_path(country, gm: @gm)
@@ -45,20 +45,32 @@
           - if @location.tag_id == 2
             - @connections.where(:parent_location_id => @location.id).each do |connection|
               - @regions.where(:id => connection.child_location_id).each do |region|
-                %tr
-                  %td= link_to "#{region.name}", location_path(region, gm: @gm)
+                - if region.hidden == true
+                  %tr
+                    %td= link_to "#{region.name} - (hidden to players)", location_path(region, gm: @gm)
+                - else
+                  %tr
+                    %td= link_to "#{region.name}", location_path(country, gm: @gm)
           
           - if @location.tag_id == 3
             - @connections.where(:parent_location_id => @location.id).each do |connection|
               - @cities.where(:id => connection.child_location_id).each do |city|
-                %tr
-                  %td= link_to "#{city.name}", location_path(city, gm: @gm)
+                - if city.hidden == true
+                  %tr
+                    %td= link_to "#{city.name} - (hidden to players)", location_path(city, gm: @gm)
+                - else
+                  %tr
+                    %td= link_to "#{city.name}", location_path(country, gm: @gm)
                   
           - if @location.tag_id == 4
             - @connections.where(:parent_location_id => @location.id).each do |connection|
               - @buildings.where(:id => connection.child_location_id).each do |building|
-                %tr
-                  %td= link_to "#{building.name}", location_path(building, gm: @gm)
+                - if building.hidden == true
+                  %tr
+                    %td= link_to "#{building.name} - (hidden to players)", location_path(building, gm: @gm)
+                - else
+                  %tr
+                    %td= link_to "#{building.name}", location_path(country, gm: @gm)
 
 - else
   .left.column

--- a/world-builder/app/views/locations/show.html.haml
+++ b/world-builder/app/views/locations/show.html.haml
@@ -50,7 +50,7 @@
                     %td= link_to "#{region.name} - (hidden to players)", location_path(region, gm: @gm)
                 - else
                   %tr
-                    %td= link_to "#{region.name}", location_path(country, gm: @gm)
+                    %td= link_to "#{region.name}", location_path(region, gm: @gm)
           
           - if @location.tag_id == 3
             - @connections.where(:parent_location_id => @location.id).each do |connection|
@@ -60,7 +60,7 @@
                     %td= link_to "#{city.name} - (hidden to players)", location_path(city, gm: @gm)
                 - else
                   %tr
-                    %td= link_to "#{city.name}", location_path(country, gm: @gm)
+                    %td= link_to "#{city.name}", location_path(city, gm: @gm)
                   
           - if @location.tag_id == 4
             - @connections.where(:parent_location_id => @location.id).each do |connection|
@@ -70,7 +70,7 @@
                     %td= link_to "#{building.name} - (hidden to players)", location_path(building, gm: @gm)
                 - else
                   %tr
-                    %td= link_to "#{building.name}", location_path(country, gm: @gm)
+                    %td= link_to "#{building.name}", location_path(building, gm: @gm)
 
 - else
   .left.column

--- a/world-builder/app/views/tags/new.html.haml
+++ b/world-builder/app/views/tags/new.html.haml
@@ -5,7 +5,7 @@
     = label :tag, :name, 'Name'
     = text_field :tag, :name
     
-    =label :tag, :rank, 'rank'
+    = label :tag, :rank, 'rank'
     = number_field :tag, :rank
 
     = submit_tag 'Save Changes'

--- a/world-builder/db/migrate/20190405235827_create_locations.rb
+++ b/world-builder/db/migrate/20190405235827_create_locations.rb
@@ -5,6 +5,7 @@ class CreateLocations < ActiveRecord::Migration
       t.text 'description'
       t.text 'gm_note'
       t.text 'player_note'
+      t.boolean 'hidden'
       t.references 'world'
       t.references 'tag'
       t.timestamps

--- a/world-builder/db/schema.rb
+++ b/world-builder/db/schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20190419052723) do
     t.text     "description"
     t.text     "gm_note"
     t.text     "player_note"
+    t.boolean  "hidden"
     t.integer  "world_id"
     t.integer  "tag_id"
     t.datetime "created_at"

--- a/world-builder/db/seeds.rb
+++ b/world-builder/db/seeds.rb
@@ -84,11 +84,19 @@ more_tags.each do |tag|
     end
 
 more_locations = [
-    { :name =>'Hidden Contient', :description => 'The location of this place is unknown', :gm_note => 'Was once a part of the contient, but disapeared when cursed', :player_note => 'Location is not know', :world_id => 4 , :tag_id => 1},
-    { :name =>'Hidden Country', :description => 'The location of this place is unknown', :gm_note => 'Was once a part of the contient, but disapeared when cursed', :player_note => 'Location is not know', :world_id => 4  , :tag_id => 2},
-    { :name =>'Barovia', :description => 'The land is surrounded by mist', :gm_note => 'This land is cursed because of Strhad ', :player_note => 'Place is scary', :world_id => 4 , :tag_id => 3},
-    { :name =>'Village of Barovia', :description => 'Small village of people', :gm_note => 'People are always gloomy and there is a haunted house', :player_note => 'Place is gloomy feeling', :world_id => 4  , :tag_id => 4},
-    { :name =>'Blood of the Vine Tavern', :description => 'Blood of the Vine Tavern a sign outside claims to be this location', :gm_note => 'three people work here', :player_note => 'There is a fire place inside', :world_id => 4  , :tag_id => 5}
+    { :name =>'Hidden Contient', :description => 'The location of this place is unknown', :gm_note => 'Was once a part of the contient, but disapeared when cursed', :player_note => 'Location is not know', :world_id => 4 , :tag_id => 1,:hidden => false},
+    { :name =>'Hidden Country Main', :description => 'The location of this place is unknown', :gm_note => 'Was once a part of the contient, but disapeared when cursed', :player_note => 'Location is not know', :world_id => 4  , :tag_id => 2,:hidden => false},
+    { :name =>'Hidden Country2', :description => 'The location of this place is unknown', :gm_note => 'Was once a part of the contient, but disapeared when cursed', :player_note => 'Location is not know', :world_id => 4  , :tag_id => 2,:hidden => true},
+    { :name =>'Hidden Country3', :description => 'The location of this place is unknown', :gm_note => 'Was once a part of the contient, but disapeared when cursed', :player_note => 'Location is not know', :world_id => 4  , :tag_id => 2,:hidden => false},
+    { :name =>'Barovia main', :description => 'The land is surrounded by mist', :gm_note => 'This land is cursed because of Strhad ', :player_note => 'Place is scary', :world_id => 4 , :tag_id => 3,:hidden => false},
+    { :name =>'Barovia2', :description => 'The land is surrounded by mist', :gm_note => 'This land is cursed because of Strhad ', :player_note => 'Place is scary', :world_id => 4 , :tag_id => 3,:hidden => true},
+    { :name =>'Barovia3', :description => 'The land is surrounded by mist', :gm_note => 'This land is cursed because of Strhad ', :player_note => 'Place is scary', :world_id => 4 , :tag_id => 3,:hidden => true},
+    { :name =>'Village of Barovia Main', :description => 'Small village of people', :gm_note => 'People are always gloomy and there is a haunted house', :player_note => 'Place is gloomy feeling', :world_id => 4  , :tag_id => 4, :hidden => false},
+    { :name =>'Village of Barovia2', :description => 'Small village of people', :gm_note => 'People are always gloomy and there is a haunted house', :player_note => 'Place is gloomy feeling', :world_id => 4  , :tag_id => 4, :hidden => true},
+    { :name =>'Village of Barovia3', :description => 'Small village of people', :gm_note => 'People are always gloomy and there is a haunted house', :player_note => 'Place is gloomy feeling', :world_id => 4  , :tag_id => 4, :hidden => false},
+    { :name =>'Blood of the Vine Tavern1', :description => 'Blood of the Vine Tavern a sign outside claims to be this location', :gm_note => 'three people work here', :player_note => 'There is a fire place inside', :world_id => 4  , :tag_id => 5,:hidden => false},
+    { :name =>'Blood of the Vine Tavern2', :description => 'Blood of the Vine Tavern a sign outside claims to be this location', :gm_note => 'three people work here', :player_note => 'There is a fire place inside', :world_id => 4  , :tag_id => 5,:hidden => false},
+    { :name =>'Blood of the Vine Tavern3', :description => 'Blood of the Vine Tavern a sign outside claims to be this location', :gm_note => 'three people work here', :player_note => 'There is a fire place inside', :world_id => 4  , :tag_id => 5,:hidden => false}
     ]
  
  more_locations.each do |location|
@@ -106,9 +114,20 @@ more_npcs.each do |npc|
 
 more_connections = [
     { :parent_location_id => 1 , :child_location_id => 2},
-    { :parent_location_id => 2 , :child_location_id => 3},
-    { :parent_location_id => 3 , :child_location_id => 4},
-    { :parent_location_id => 4 , :child_location_id => 5}	
+    { :parent_location_id => 1 , :child_location_id => 3},
+    { :parent_location_id => 1 , :child_location_id => 4},
+    
+    { :parent_location_id => 2 , :child_location_id => 5},
+    { :parent_location_id => 2 , :child_location_id => 6},
+    { :parent_location_id => 2 , :child_location_id => 7},
+    
+    { :parent_location_id => 5 , :child_location_id => 8},
+    { :parent_location_id => 5 , :child_location_id => 9},
+    { :parent_location_id => 5 , :child_location_id => 10},
+    
+    { :parent_location_id => 8 , :child_location_id => 11},
+    { :parent_location_id => 8 , :child_location_id => 12},
+    { :parent_location_id => 8 , :child_location_id => 13}
     ]
     
 more_connections.each do |connection|


### PR DESCRIPTION
This allows GM to see all locations regardless of if they are set as hidden, and allows them to toggle hidden for each location, giving players access to those locations. Players cannot see hidden locations and are not able to edit any locations within campaigns they are not the GM of
